### PR TITLE
Proper handling of keyword definition PHP files

### DIFF
--- a/robotremote-tests/ClassFinderTest.php
+++ b/robotremote-tests/ClassFinderTest.php
@@ -30,8 +30,31 @@ class ClassFinderTests extends PHPUnit_Framework_TestCase {
                 )), $found);
     }
 
-    // TODO tests with multiple files
-    // TODO tests with multiple classes in single file
-    // TODO tests with use of namespace in files
+    public function testMultipleClassesWithNamespace() {
+        $found = $this->classFinder->findFunctionsByClasses(__DIR__.'/test-libraries-multiple-files/another-subfolder/ClassesWithNamespace.php');
+
+        $this->assertEquals(array(
+            '\\TestNamespace\\ClassWithNamespace1' => array(
+                'keywordWithNamespace1' => array(
+                    'arguments' => array(),
+                    'documentation' => ''),
+                ),
+            '\\TestNamespace\\ClassWithNamespace2' => array(
+                'keywordWithNamespace2' => array(
+                    'arguments' => array(),
+                    'documentation' => ''),
+                ),
+            '\\TestNamespace\\ClassWithNamespace3' => array(
+                'keywordWithNamespace3' => array(
+                    'arguments' => array(),
+                    'documentation' => ''),
+                'keywordWithNamespace4' => array(
+                    'arguments' => array(),
+                    'documentation' => ''),
+                'keywordWithNamespace5' => array(
+                    'arguments' => array(),
+                    'documentation' => ''),
+                )), $found);
+    }
 
 }

--- a/robotremote-tests/ClassFinderTest.php
+++ b/robotremote-tests/ClassFinderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use \PhpRobotRemoteServer\ClassFinder;
+
+class ClassFinderTests extends PHPUnit_Framework_TestCase {
+
+    protected function setUp() {
+
+    }
+
+    protected function tearDown() {
+
+    }
+
+    public function testSingleClass() {
+        $found = ClassFinder::findFunctionsByClasses(__DIR__.'/test-libraries/ExampleLibrary.php');
+
+        $this->assertEquals(array(
+            '\\ExampleLibrary' => array(
+                'truth_of_life' => array(
+                    'arguments' => array(),
+                    'documentation' => ''),
+                'strings_should_be_equal' => array(
+                    'arguments' => array('$str1', '$str2'),
+                    'documentation' => '/**
+   * Compare 2 strings. If they are not equal, throws exception.
+   */')
+                )), $found);
+    }
+
+    // TODO tests with multiple files
+    // TODO tests with multiple classes in single file
+    // TODO tests with use of namespace in files
+
+}

--- a/robotremote-tests/ClassFinderTest.php
+++ b/robotremote-tests/ClassFinderTest.php
@@ -4,8 +4,10 @@ use \PhpRobotRemoteServer\ClassFinder;
 
 class ClassFinderTests extends PHPUnit_Framework_TestCase {
 
-    protected function setUp() {
+    private $classFinder;
 
+    protected function setUp() {
+        $this->classFinder = new ClassFinder();
     }
 
     protected function tearDown() {
@@ -13,7 +15,7 @@ class ClassFinderTests extends PHPUnit_Framework_TestCase {
     }
 
     public function testSingleClass() {
-        $found = ClassFinder::findFunctionsByClasses(__DIR__.'/test-libraries/ExampleLibrary.php');
+        $found = $this->classFinder->findFunctionsByClasses(__DIR__.'/test-libraries/ExampleLibrary.php');
 
         $this->assertEquals(array(
             '\\ExampleLibrary' => array(

--- a/robotremote-tests/FullProtocolTest.php
+++ b/robotremote-tests/FullProtocolTest.php
@@ -120,7 +120,7 @@ class FullProtocolTests extends PHPUnit_Framework_TestCase {
 <value><string>Given strings are not equal</string></value>
 </member>
 <member><name>traceback</name>
-<value><string>#0 [internal function]: ExampleLibrary-&gt;strings_should_be_equal(&apos;abc&apos;, &apos;def&apos;)';
+<value><string>#0 [internal function]: ExampleLibrary::strings_should_be_equal(&apos;abc&apos;, &apos;def&apos;)';
         $this->assertTrue(strpos($actualRpcAnswer, $toCheck) === 0, $actualRpcAnswer."\nDO NOT START WITH\n".$toCheck);
     }
 

--- a/robotremote-tests/HighLevelKeywordStoreTest.php
+++ b/robotremote-tests/HighLevelKeywordStoreTest.php
@@ -2,7 +2,7 @@
 
 use \PhpRobotRemoteServer\KeywordStore;
 
-class KeywordStoreTests extends PHPUnit_Framework_TestCase {
+class HighLevelKeywordStoreTests extends PHPUnit_Framework_TestCase {
 
     private $keywordStore;
 
@@ -22,6 +22,10 @@ class KeywordStoreTests extends PHPUnit_Framework_TestCase {
         $this->assertEquals('truth_of_life', $keywordNames[0]);
         $this->assertEquals('strings_should_be_equal', $keywordNames[1]);
     }
+
+    // TODO tests with multiple files
+    // TODO tests with multiple classes in single file
+    // TODO tests with use of namespace in files
 
     public function testExecKeyword() {
         $args = array();

--- a/robotremote-tests/HighLevelKeywordStoreTest.php
+++ b/robotremote-tests/HighLevelKeywordStoreTest.php
@@ -23,10 +23,6 @@ class HighLevelKeywordStoreTests extends PHPUnit_Framework_TestCase {
         $this->assertEquals('strings_should_be_equal', $keywordNames[1]);
     }
 
-    // TODO tests with multiple files
-    // TODO tests with multiple classes in single file
-    // TODO tests with use of namespace in files
-
     public function testExecKeyword() {
         $args = array();
         $result = $this->keywordStore->execKeyword('truth_of_life', $args);
@@ -75,5 +71,32 @@ class HighLevelKeywordStoreTests extends PHPUnit_Framework_TestCase {
     }
 
     // TODO special characters in doc
+
+    public function testExecKeywordMultipleFiles() {
+        $this->keywordStore->collectKeywords(__DIR__.'/test-libraries-multiple-files');
+
+        $keywordsToTest = array(
+            'keywordWithNamespace1',
+            'keywordWithNamespace2',
+            'keywordWithNamespace3',
+            'keywordWithNamespace4',
+            'keywordWithNamespace5',
+            'deeplyNestedKeyword1',
+            'deeplyNestedKeyword2',
+            'deeplyNestedKeyword3',
+            'keywordInSameFolder1',
+            'keywordInSameFolder2',
+            'keywordInSameFolder3',
+            'keywordInSameFolder4',
+            'keywordInSameFolder5',
+            );
+
+        foreach ($keywordsToTest as $keywordName) {
+            $args = array();
+            $result = $this->keywordStore->execKeyword($keywordName, $args);
+
+            $this->assertEquals($keywordName, $result);
+        }
+    }
 
 }

--- a/robotremote-tests/KeywordStoreTest.php
+++ b/robotremote-tests/KeywordStoreTest.php
@@ -2,7 +2,7 @@
 
 use \PhpRobotRemoteServer\KeywordStore;
 
-class KeywordStoreTests extends PHPUnit_Framework_TestCase {
+class KeywordStoreTest extends PHPUnit_Framework_TestCase {
 
     protected function setUp() {
 
@@ -42,10 +42,19 @@ class KeywordStoreTests extends PHPUnit_Framework_TestCase {
         $this->assertEquals('Compare 2 strings. If they are not equal, throws exception.', $actual);
     }
 
+    public function testFindFiles() {
+        $rootDir = __DIR__.'/test-libraries';
+        $keywordStore = new KeywordStore();
+        $files = $keywordStore->findFiles($rootDir);
+        $this->assertEquals(array(
+                $rootDir.'/ExampleLibrary.php'
+            ), $files);
+    }
+
     public function testCollectKeywordsFromFile() {
         $file = __DIR__.'/test-libraries/ExampleLibrary.php';
         $keywordStore = new KeywordStore();
-        $keywordStore->collectKeywordsFromFile(__DIR__.'/test-libraries/ExampleLibrary.php');
+        $keywordStore->collectKeywordsFromFile($file);
         $keywords = $keywordStore->keywords;
         $this->assertEquals(array(
             'truth_of_life' => array(

--- a/robotremote-tests/KeywordStoreTest.php
+++ b/robotremote-tests/KeywordStoreTest.php
@@ -42,12 +42,28 @@ class KeywordStoreTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('Compare 2 strings. If they are not equal, throws exception.', $actual);
     }
 
-    public function testFindFiles() {
+    public function testFindFilesBasic() {
         $rootDir = __DIR__.'/test-libraries';
         $keywordStore = new KeywordStore();
         $files = $keywordStore->findFiles($rootDir);
         $this->assertEquals(array(
                 $rootDir.'/ExampleLibrary.php'
+            ), $files);
+    }
+
+    public function testFindFilesMultipleFiles() {
+        $rootDir = __DIR__.'/test-libraries-multiple-files';
+        $keywordStore = new KeywordStore();
+        $files = $keywordStore->findFiles($rootDir);
+
+        // Make sure check do not depend on the order of the elements: sorting the result
+        natsort($files);
+        $this->assertEquals(array(
+                $rootDir.'/another-subfolder/ClassesWithNamespace.php',
+                $rootDir.'/subfolder/MultipleClassInSameFolder1.php',
+                $rootDir.'/subfolder/MultipleClassInSameFolder2.php',
+                $rootDir.'/subfolder/MultipleClassInSameFolder3.php',
+                $rootDir.'/subfolder/deeply-nested/DeeplyNestedClasses.php',
             ), $files);
     }
 
@@ -70,7 +86,80 @@ class KeywordStoreTest extends PHPUnit_Framework_TestCase {
              ), $keywords);
     }
 
-    // TODO multiple classes in same file
-    // TODO multiple files
+    public function testCollectKeywordsMultipleFiles() {
+        $rootDir = __DIR__.'/test-libraries-multiple-files';
+        $keywordStore = new KeywordStore();
+        $keywordStore->collectKeywords($rootDir);
+        $keywords = $keywordStore->keywords;
+        $this->assertEquals(array(
+            'keywordWithNamespace1' => array(
+                    'file' => $rootDir.'/another-subfolder/ClassesWithNamespace.php',
+                    'class' => '\\TestNamespace\\ClassWithNamespace1',
+                    'arguments' => array(),
+                    'documentation' => ''),
+            'keywordWithNamespace2' => array(
+                    'file' => $rootDir.'/another-subfolder/ClassesWithNamespace.php',
+                    'class' => '\\TestNamespace\\ClassWithNamespace2',
+                    'arguments' => array(),
+                    'documentation' => ''),
+            'keywordWithNamespace3' => array(
+                    'file' => $rootDir.'/another-subfolder/ClassesWithNamespace.php',
+                    'class' => '\\TestNamespace\\ClassWithNamespace3',
+                    'arguments' => array(),
+                    'documentation' => ''),
+            'keywordWithNamespace4' => array(
+                    'file' => $rootDir.'/another-subfolder/ClassesWithNamespace.php',
+                    'class' => '\\TestNamespace\\ClassWithNamespace3',
+                    'arguments' => array(),
+                    'documentation' => ''),
+            'keywordWithNamespace5' => array(
+                    'file' => $rootDir.'/another-subfolder/ClassesWithNamespace.php',
+                    'class' => '\\TestNamespace\\ClassWithNamespace3',
+                    'arguments' => array(),
+                    'documentation' => ''),
+
+            'deeplyNestedKeyword1' => array(
+                    'file' => $rootDir.'/subfolder/deeply-nested/DeeplyNestedClasses.php',
+                    'class' => '\\DeeplyNestedClass1',
+                    'arguments' => array(),
+                    'documentation' => ''),
+            'deeplyNestedKeyword2' => array(
+                    'file' => $rootDir.'/subfolder/deeply-nested/DeeplyNestedClasses.php',
+                    'class' => '\\DeeplyNestedClass1',
+                    'arguments' => array(),
+                    'documentation' => ''),
+            'deeplyNestedKeyword3' => array(
+                    'file' => $rootDir.'/subfolder/deeply-nested/DeeplyNestedClasses.php',
+                    'class' => '\\DeeplyNestedClass2',
+                    'arguments' => array(),
+                    'documentation' => ''),
+
+            'keywordInSameFolder1' => array(
+                    'file' => $rootDir.'/subfolder/MultipleClassInSameFolder1.php',
+                    'class' => '\\MultipleClassInSameFolder1',
+                    'arguments' => array(),
+                    'documentation' => ''),
+            'keywordInSameFolder2' => array(
+                    'file' => $rootDir.'/subfolder/MultipleClassInSameFolder1.php',
+                    'class' => '\\MultipleClassInSameFolder1',
+                    'arguments' => array(),
+                    'documentation' => ''),
+            'keywordInSameFolder3' => array(
+                    'file' => $rootDir.'/subfolder/MultipleClassInSameFolder1.php',
+                    'class' => '\\MultipleClassInSameFolder1',
+                    'arguments' => array(),
+                    'documentation' => ''),
+            'keywordInSameFolder4' => array(
+                    'file' => $rootDir.'/subfolder/MultipleClassInSameFolder2.php',
+                    'class' => '\\MultipleClassInSameFolder2',
+                    'arguments' => array(),
+                    'documentation' => ''),
+            'keywordInSameFolder5' => array(
+                    'file' => $rootDir.'/subfolder/MultipleClassInSameFolder3.php',
+                    'class' => '\\MultipleClassInSameFolder3',
+                    'arguments' => array(),
+                    'documentation' => ''),
+             ), $keywords);
+    }
 
 }

--- a/robotremote-tests/KeywordStoreTests.php
+++ b/robotremote-tests/KeywordStoreTests.php
@@ -1,0 +1,67 @@
+<?php
+
+use \PhpRobotRemoteServer\KeywordStore;
+
+class KeywordStoreTests extends PHPUnit_Framework_TestCase {
+
+    protected function setUp() {
+
+    }
+
+    protected function tearDown() {
+
+    }
+
+    public function testCleanUpPhpArguments() {
+        $rawArguments = array(
+            '$abc',
+            '$prettymegagigalongandthatsnothngyetboooooyaaaaaa',
+            '$o',
+            '$somanyparameters'
+            );
+        $actual = KeywordStore::cleanUpPhpArguments($rawArguments);
+        $this->assertEquals(array(
+            'abc',
+            'prettymegagigalongandthatsnothngyetboooooyaaaaaa',
+            'o',
+            'somanyparameters'
+            ), $actual);
+    }
+
+    public function testCleanUpPhpArgumentsNoArgs() {
+        $rawArguments = array();
+        $actual = KeywordStore::cleanUpPhpArguments($rawArguments);
+        $this->assertEquals(array(), $actual);
+    }
+
+    public function testCleanUpPhpDocumentation() {
+        $rawDocumentation = '/**
+   * Compare 2 strings. If they are not equal, throws exception.
+   */';
+        $actual = KeywordStore::cleanUpPhpDocumentation($rawDocumentation);
+        $this->assertEquals('Compare 2 strings. If they are not equal, throws exception.', $actual);
+    }
+
+    public function testCollectKeywordsFromFile() {
+        $file = __DIR__.'/test-libraries/ExampleLibrary.php';
+        $keywordStore = new KeywordStore();
+        $keywordStore->collectKeywordsFromFile(__DIR__.'/test-libraries/ExampleLibrary.php');
+        $keywords = $keywordStore->keywords;
+        $this->assertEquals(array(
+            'truth_of_life' => array(
+                    'file' => $file,
+                    'class' => '\\ExampleLibrary',
+                    'arguments' => array(),
+                    'documentation' => ''),
+            'strings_should_be_equal' => array(
+                    'file' => $file,
+                    'class' => '\\ExampleLibrary',
+                    'arguments' => array('str1', 'str2'),
+                    'documentation' => 'Compare 2 strings. If they are not equal, throws exception.')
+             ), $keywords);
+    }
+
+    // TODO multiple classes in same file
+    // TODO multiple files
+
+}

--- a/robotremote-tests/RobotRemoteProtocolTests.php
+++ b/robotremote-tests/RobotRemoteProtocolTests.php
@@ -1,7 +1,0 @@
-<?php
-
-use \PhpRobotRemoteServer\KeywordStore;
-
-class RobotRemoteProtocolTests extends PHPUnit_Framework_TestCase {
-
-}

--- a/robotremote-tests/RobotRemoteServerTest.php
+++ b/robotremote-tests/RobotRemoteServerTest.php
@@ -4,7 +4,7 @@ use \PhpRobotRemoteServer\KeywordStore;
 use \PhpRobotRemoteServer\RobotRemoteServer;
 use \PhpRobotRemoteServer\RobotRemoteProtocol;
 
-class FullProtocolTests extends PHPUnit_Framework_TestCase {
+class FullProtocolTest extends PHPUnit_Framework_TestCase {
 
     private $fakeRequests;
     private $fakeResponses;

--- a/robotremote-tests/test-libraries-multiple-files/another-subfolder/ClassesWithNamespace.php
+++ b/robotremote-tests/test-libraries-multiple-files/another-subfolder/ClassesWithNamespace.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace TestNamespace;
+
+class ClassWithNamespace1 {
+
+  public function keywordWithNamespace1() {
+    return __FUNCTION__;
+  }
+
+}
+
+class ClassWithNamespace2 {
+
+  public function keywordWithNamespace2() {
+    return __FUNCTION__;
+  }
+
+}
+
+class ClassWithNamespace3 {
+
+  public function keywordWithNamespace3() {
+    return __FUNCTION__;
+  }
+
+  public function keywordWithNamespace4() {
+    return __FUNCTION__;
+  }
+
+  public function keywordWithNamespace5() {
+    return __FUNCTION__;
+  }
+
+}

--- a/robotremote-tests/test-libraries-multiple-files/subfolder/MultipleClassInSameFolder1.php
+++ b/robotremote-tests/test-libraries-multiple-files/subfolder/MultipleClassInSameFolder1.php
@@ -1,0 +1,16 @@
+<?php
+class MultipleClassInSameFolder1 {
+
+  public function keywordInSameFolder1() {
+    return __FUNCTION__;
+  }
+
+  public function keywordInSameFolder2() {
+    return __FUNCTION__;
+  }
+
+  public function keywordInSameFolder3() {
+    return __FUNCTION__;
+  }
+
+}

--- a/robotremote-tests/test-libraries-multiple-files/subfolder/MultipleClassInSameFolder2.php
+++ b/robotremote-tests/test-libraries-multiple-files/subfolder/MultipleClassInSameFolder2.php
@@ -1,0 +1,8 @@
+<?php
+class MultipleClassInSameFolder2 {
+
+  public function keywordInSameFolder4() {
+  	return __FUNCTION__;
+  }
+
+}

--- a/robotremote-tests/test-libraries-multiple-files/subfolder/MultipleClassInSameFolder3.php
+++ b/robotremote-tests/test-libraries-multiple-files/subfolder/MultipleClassInSameFolder3.php
@@ -1,0 +1,8 @@
+<?php
+class MultipleClassInSameFolder3 {
+
+  public function keywordInSameFolder5() {
+    return __FUNCTION__;
+  }
+
+}

--- a/robotremote-tests/test-libraries-multiple-files/subfolder/deeply-nested/DeeplyNestedClasses.php
+++ b/robotremote-tests/test-libraries-multiple-files/subfolder/deeply-nested/DeeplyNestedClasses.php
@@ -1,0 +1,20 @@
+<?php
+class DeeplyNestedClass1 {
+
+  public function deeplyNestedKeyword1() {
+    return __FUNCTION__;
+  }
+
+  public function deeplyNestedKeyword2() {
+    return __FUNCTION__;
+  }
+
+}
+
+class DeeplyNestedClass2 {
+
+  public function deeplyNestedKeyword3() {
+    return __FUNCTION__;
+  }
+
+}

--- a/robotremote/ClassFinder.php
+++ b/robotremote/ClassFinder.php
@@ -11,7 +11,7 @@ namespace PhpRobotRemoteServer;
  */
 class ClassFinder {
 
-	public static function findFunctionsByClasses($file) {
+	public function findFunctionsByClasses($file) {
 		$fqnClassesFunctions = array();
 
 		$currentNamespace = '';

--- a/robotremote/ClassFinder.php
+++ b/robotremote/ClassFinder.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace PhpRobotRemoteServer;
+
+/*
+ * Originaly taken from:
+ * http://stackoverflow.com/questions/7153000/get-class-name-from-file
+ * Then grown to support multiple classes, and to return a complex associative
+ * array of all the functions associated with each class, with arguments and
+ * documentation for each function.
+ */
+class ClassFinder {
+
+	public static function findFunctionsByClasses($file) {
+		$fqnClassesFunctions = array();
+
+		$currentNamespace = '';
+		$currentClass = '';
+		$lastDoc = '';
+
+		$fp = fopen($file, 'r');
+		$buffer = '';
+		$i = 0;
+		while (!feof($fp)) {
+
+		    $buffer .= fread($fp, 512);
+		    $tokens = token_get_all($buffer);
+
+		    if (strpos($buffer, '{') === false) continue;
+
+		    for (;$i<count($tokens);$i++) {
+		        if ($tokens[$i][0] === T_NAMESPACE) {
+		            for ($j=$i+1;$j<count($tokens); $j++) {
+		                if ($tokens[$j][0] === T_STRING) {
+		                     $currentNamespace .= '\\'.$tokens[$j][1];
+		                } else if ($tokens[$j] === '{' || $tokens[$j] === ';') {
+		                     break;
+		                }
+		            }
+		        }
+
+		        if ($tokens[$i][0] === T_CLASS) {
+		            for ($j=$i+1;$j<count($tokens);$j++) {
+		                if ($tokens[$j] === '{') {
+		                    $currentClass = $tokens[$i+2][1];
+		                }
+		            }
+		        }
+
+   		        if ($tokens[$i][0] === T_DOC_COMMENT) {
+   		        	$lastDoc = $tokens[$i][1];
+   		       	} 
+				
+   		        if ($tokens[$i][0] === T_FUNCTION) {
+   		        	$arguments = array();
+		            for ($j=$i+1;$j<count($tokens);$j++) {
+		            	if ($tokens[$j][0] === T_VARIABLE) {
+		            		$arguments[] = $tokens[$j][1];
+		            	} else if ($tokens[$j] === '{') {
+		                    $function = $tokens[$i+2][1];
+		                    $fqnClass = $currentNamespace.'\\'.$currentClass;
+		                    $fqnClassesFunctions[$fqnClass][$function] = array(
+		                    	'arguments' => $arguments,
+		                    	'documentation' => $lastDoc);
+		                    $lastDoc = '';
+		                    break;
+		                }
+		            }
+		        }
+
+		    }
+		}
+
+		return $fqnClassesFunctions;
+	}
+
+}

--- a/robotremote/KeywordStore.php
+++ b/robotremote/KeywordStore.php
@@ -25,9 +25,9 @@ class KeywordStore {
     }
 
 	public function collectKeywords($keywordsDirectory) {
-		// Every php file inside $directory folder will be added.
-		// Put your PHP class file(s) into that $directory folder.
 		$files = $this->findFiles($keywordsDirectory);
+
+		$this->keywords = array();
 		foreach ($files as $file) {
 		  	$this->collectKeywordsFromFile($file);
 		}
@@ -35,19 +35,26 @@ class KeywordStore {
 
 	function findFiles($directory) {
 		$foundFiles = array();
-
-		if (is_dir($directory)) {
-		  $files = scandir($directory);
-		  foreach ($files as $file) {
-		  	$fullPathFile = $directory.'/'.$file;
-		  	if (is_file($fullPathFile)) {
-			  	$foundFiles[] = $fullPathFile;
-		  	}
-		  	// TODO else: recursive traversal of folder
-		  }
-		}
-
+		$this->recursiveFileLookup($directory, $foundFiles);
 		return $foundFiles;
+	}
+
+	private function recursiveFileLookup($directory, &$foundFiles) {
+		if (is_dir($directory)) {
+		  	$elements = scandir($directory);
+		  	foreach ($elements as $element) {
+		  		if ($element === '.' || $element === '..') {
+		  			continue;
+		  		} else {
+			  		$fullPathFile = $directory.'/'.$element;
+		  			if (is_dir($fullPathFile)) {
+			  			$this->recursiveFileLookup($fullPathFile, $foundFiles);
+		  			} else {
+				  		$foundFiles[] = $fullPathFile;
+		  			}
+		  		}
+		  	}
+		}
 	}
 
 	function collectKeywordsFromFile($file) {

--- a/robotremote/KeywordStore.php
+++ b/robotremote/KeywordStore.php
@@ -4,6 +4,8 @@ namespace PhpRobotRemoteServer;
 
 class KeywordStore {
 
+	private $classFinder;
+
 	/*
 	 * Map (associative array):
 	 *
@@ -15,24 +17,41 @@ class KeywordStore {
 	 */
 	var $keywords;
 
+    public function __construct($classFinder = NULL) {
+    	if (!$classFinder) {
+    		$classFinder = new ClassFinder();
+    	}
+    	$this->classFinder = $classFinder;
+    }
+
 	public function collectKeywords($keywordsDirectory) {
 		// Every php file inside $directory folder will be added.
 		// Put your PHP class file(s) into that $directory folder.
-		$directory = $keywordsDirectory;
+		$files = $this->findFiles($keywordsDirectory);
+		foreach ($files as $file) {
+		  	$this->collectKeywordsFromFile($file);
+		}
+	}
+
+	function findFiles($directory) {
+		$foundFiles = array();
+
 		if (is_dir($directory)) {
 		  $files = scandir($directory);
 		  foreach ($files as $file) {
 		  	$fullPathFile = $directory.'/'.$file;
 		  	if (is_file($fullPathFile)) {
-			  	$this->collectKeywordsFromFile($fullPathFile);
+			  	$foundFiles[] = $fullPathFile;
 		  	}
 		  	// TODO else: recursive traversal of folder
 		  }
 		}
+
+		return $foundFiles;
 	}
 
 	function collectKeywordsFromFile($file) {
-		$functionsByClasses = ClassFinder::findFunctionsByClasses($file);
+		$functionsByClasses = $this->classFinder->findFunctionsByClasses($file);
 		foreach ($functionsByClasses as $class => $functions) {
 			foreach ($functions as $function => $functionInfo) {
 				$rawArguments = $functionInfo['arguments'];

--- a/robotremote/RobotRemoteProtocol.php
+++ b/robotremote/RobotRemoteProtocol.php
@@ -246,7 +246,6 @@ class RobotRemoteProtocol {
 		return $keywordResult;
 	}
 
-	// TODO split this baby-monster method
 	private function run_keyword($xmlrpcMsg) {
 		try {
 			$parsedXmlrpcMsg = $this->parseXmlrpcMsg($xmlrpcMsg);


### PR DESCRIPTION
We want to support keyword definition in multiple files. Ready to merge.

What have been done:
- Reflection is not used anymore to gather the list of available keywords and their associated info (arguments, documentation)
- Instead, the files are analyzed with a tokenizer to extract all the functions as keywords, and to associate them to the corresponding class and namespace; arguments and documentation info are also extracted
- We end up with a data structure in memory that maps any given keyword to: the file where it is defined, the class defining the keyword (including the namespace), the arguments of the keyword, and its documentation
- Getting the list of keywords, and getting arguments or documentation of any keyword becomes trivial
- Executing a keyword proceeds by requiring the file, then building the full name of the function to call by appending the class name and keyword name and calling this function statically ('::' is used, we do not create any class instance)
- Files are thus only required when needed; also instances creation are solely at the initiative of the keyword implementor (typically done on the test model, not into the Robot Framework link code)
- The keyword directory is crawled recursively for keyword files
- Unit tests on file crawling, file analysis (using the tokenizer), executing keywords from multiple files and classes
